### PR TITLE
Add 'dict' option for using custom dict file when using nvim-cmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is [look](https://man7.org/linux/man-pages/man1/look.1.html) source for [hr
 ## For nvim-cmp
 ```lua
 require('cmp').setup({
-  sources={{name='look', keyword_length=2, option={convert_case=true, loud=true}}}
+  sources={{name='look', keyword_length=2, option={convert_case=true, loud=true, dict='/usr/share/dict/words'}}}
 })
 ```
 

--- a/lua/cmp_look/init.lua
+++ b/lua/cmp_look/init.lua
@@ -121,13 +121,14 @@ M.complete = function(self, request, callback)
   local q = string.sub(request.context.cursor_before_line, request.offset)
   local should_convert_case = request.option.convert_case or false
   local loud = request.option.loud or false
+  local dict = request.option.dict or ''
   local stdioe = pipes()
   local handle, pid
   local buf = ''
   local words = {}
   do
     local spawn_params = {
-      args = {'--', q},
+      args = {'--', q, dict},
       stdio = stdioe
     }
     handle, pid = luv.spawn('look', spawn_params, function(code, signal)


### PR DESCRIPTION
This command option, 'dict', allows users to change the dictionary file that 'look' is using.
It also makes this plugin able to use on Windows (with Cygwin‘s 'look' executable in %PATH%).

I'm not familiar with ddc, so this modification is only for nvim-cmp.